### PR TITLE
common code for jlab3 and jlab4

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,16 +43,16 @@ interface IJupytextFormat {
   label: string;
 }
 
-interface JupytextRepresentation {
+interface IJupytextRepresentation {
   format_name: string;
   extension: string;
 }
 
-interface JupytextSection {
+interface IJupytextSection {
   formats?: string;
   notebook_metadata_filter?: string;
   cell_metadata_filter?: string;
-  text_representation?: JupytextRepresentation;
+  text_representation?: IJupytextRepresentation;
 }
 
 function getJupytextFormats(trans: TranslationBundle): IJupytextFormat[] {
@@ -110,7 +110,7 @@ function getJupytextFormats(trans: TranslationBundle): IJupytextFormat[] {
 const LANGUAGE_INDEPENDENT_NOTEBOOK_EXTENSIONS = ["ipynb", "md", "Rmd", "qmd"];
 
 // will get updated upon activation
-let JLAB4 = true
+let JLAB4 = true;
 
 function get_jupytext_formats(notebook_tracker: INotebookTracker): Array<string> {
   if (!notebook_tracker.currentWidget) return [];
@@ -124,9 +124,9 @@ function get_jupytext_formats(notebook_tracker: INotebookTracker): Array<string>
   //   if (! (model.metadata as any)?.has("jupytext"))
   //     return [];
 
-  const jupytext: JupytextSection = (JLAB4
+  const jupytext: IJupytextSection = (JLAB4
     ? model.getMetadata('jupytext')
-    : (model.metadata as any)?.get('jupytext')) as unknown as JupytextSection;
+    : (model.metadata as any)?.get('jupytext')) as unknown as IJupytextSection;
   if ( ! jupytext )
     return [];
   let formats: Array<string> = jupytext && jupytext.formats ? jupytext.formats.split(',') : [];
@@ -175,9 +175,9 @@ function get_selected_formats(notebook_tracker: INotebookTracker): Array<string>
     // xxx same here, the test is probably not needed
     // if (notebook_tracker.currentWidget.context.model.metadata.has("jupytext")) {
     const model = notebook_tracker.currentWidget.context.model;
-    const jupytext: JupytextSection = (JLAB4
+    const jupytext: IJupytextSection = (JLAB4
       ? model.getMetadata('jupytext')
-      : (model.metadata as any)?.get('jupytext')) as unknown as JupytextSection;
+      : (model.metadata as any)?.get('jupytext')) as unknown as IJupytextSection;
     if (jupytext && jupytext.text_representation && jupytext.text_representation.format_name)
       format_name = jupytext.text_representation.format_name;
     // }
@@ -259,10 +259,10 @@ const extension: JupyterFrontEndPlugin<void> = {
             if ( notebookTracker.currentWidget === null)
               return;
             const model = notebookTracker.currentWidget.context.model;
-            const jupytext: JupytextSection = (JLAB4
+            const jupytext: IJupytextSection = (JLAB4
               ? model.getMetadata('jupytext')
               : (model.metadata as any)?.get('jupytext')
-            ) as unknown as JupytextSection;
+            ) as unknown as IJupytextSection;
           let formats: Array<string> = get_selected_formats(notebookTracker);
 
           // Toggle the selected format
@@ -401,7 +401,7 @@ const extension: JupyterFrontEndPlugin<void> = {
         if (!jupytext_metadata)
           return false;
 
-        const jupytext: JupytextSection = (jupytext_metadata as unknown) as JupytextSection;
+        const jupytext: IJupytextSection = (jupytext_metadata as unknown) as IJupytextSection;
 
         if (jupytext.notebook_metadata_filter === '-all')
           return false;
@@ -419,7 +419,7 @@ const extension: JupyterFrontEndPlugin<void> = {
         if (!jupytext_metadata)
           return false;
 
-        const jupytext: JupytextSection = (jupytext_metadata as unknown) as JupytextSection;
+        const jupytext: IJupytextSection = (jupytext_metadata as unknown) as IJupytextSection;
 
         if (jupytext.notebook_metadata_filter === undefined)
           return true;
@@ -441,7 +441,7 @@ const extension: JupyterFrontEndPlugin<void> = {
         if (!jupytext_metadata)
           return false;
 
-        const jupytext: JupytextSection = (jupytext_metadata as unknown) as JupytextSection;
+        const jupytext: IJupytextSection = (jupytext_metadata as unknown) as IJupytextSection;
 
         if (jupytext.notebook_metadata_filter) {
           delete jupytext.notebook_metadata_filter;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,6 @@ import {
 
 import { markdownIcon } from "@jupyterlab/ui-components";
 
-// used to compute the global JLAB4
-import { SemVer } from "semver";
-
 interface IJupytextFormat {
   /**
    * Conversion format
@@ -215,7 +212,16 @@ const extension: JupyterFrontEndPlugin<void> = {
     translator: ITranslator | null,
     palette: ICommandPalette | null
   ) => {
-    JLAB4 = new SemVer(app.version).compare('4.0.0') >= 0;
+    // https://semver.org/#semantic-versioning-specification-semver
+    // npm semver requires pre-release versions to come with a hyphen
+    // so 7.0.0rc2 won't work with semver
+    // in addition, when running in the notebook7 context, app.version
+    // returns the notebook's version, not jupyterlab !
+    // ignoring the second point for now (it accidentally works...)
+    const app_numbers = app.version.match(/[0-9]+/)
+    if (app_numbers) {
+      JLAB4 = parseInt(app_numbers[0]) >= 4;
+    }
     console.log("JupyterLab extension jupyterlab-jupytext is activated!");
     console.debug(`JLAB4=${JLAB4}`);
     const trans = (translator ?? nullTranslator).load("jupytext");

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,7 +216,8 @@ const extension: JupyterFrontEndPlugin<void> = {
     palette: ICommandPalette | null
   ) => {
     JLAB4 = new SemVer(app.version).compare('4.0.0') >= 0;
-    console.log(`JupyterLab extension jupyterlab-jupytext is activated, JLAB4=${JLAB4}`);
+    console.log("JupyterLab extension jupyterlab-jupytext is activated!");
+    console.debug(`JLAB4=${JLAB4}`);
     const trans = (translator ?? nullTranslator).load("jupytext");
 
     // Jupytext formats

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,8 @@ function getJupytextFormats(trans: TranslationBundle): IJupytextFormat[] {
 const LANGUAGE_INDEPENDENT_NOTEBOOK_EXTENSIONS = ["ipynb", "md", "Rmd", "qmd"];
 
 // will get updated upon activation
+// default is true, and we will turn this off only iff
+// app.name is "JupyterLab" and the version is 3.x or below
 let JLAB4 = true;
 
 function get_jupytext_formats(notebook_tracker: INotebookTracker): Array<string> {
@@ -215,12 +217,13 @@ const extension: JupyterFrontEndPlugin<void> = {
     // https://semver.org/#semantic-versioning-specification-semver
     // npm semver requires pre-release versions to come with a hyphen
     // so 7.0.0rc2 won't work with semver
-    // in addition, when running in the notebook7 context, app.version
-    // returns the notebook's version, not jupyterlab !
-    // ignoring the second point for now (it accidentally works...)
-    const app_numbers = app.version.match(/[0-9]+/)
-    if (app_numbers) {
-      JLAB4 = parseInt(app_numbers[0]) >= 4;
+    // in addition, when running in the notebook7 context, app refers
+    // to the notebook7 application, not the jupyterlab application
+    if (app.name == "JupyterLab") {
+      const app_numbers = app.version.match(/[0-9]+/);
+      if (app_numbers) {
+        JLAB4 = parseInt(app_numbers[0]) >= 4;
+      }
     }
     console.log("JupyterLab extension jupyterlab-jupytext is activated!");
     console.debug(`JLAB4=${JLAB4}`);


### PR DESCRIPTION
as mentioned in #3, here is a draft version that
- works with jlab4 (manually tested)
- should work with jlab3 - ***NOT TESTED*** because I am in no position to test on jlab3 (have never used jlab3 actually..)

I have not received any suggestion yet on
https://discourse.jupyter.org/t/jlab-extensions-that-target-both-jlab3-and-jlab4/

so I went ahead on my own and came up with this strategy, that computes a global `JLAB4` variable
glad to hear if that is improvable




